### PR TITLE
Add coverage config and docs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = src
+omit = */tests/*

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ Install dependencies from `src/requirements.txt` and run `pytest`:
 pip install -r src/requirements.txt
 pytest
 ```
+
+To generate an HTML coverage report, run:
+
+```bash
+coverage html
+```
+
+The report will be available in the `htmlcov` directory.


### PR DESCRIPTION
## Summary
- configure coverage.py with `.coveragerc`
- document generating HTML coverage report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1ce043948330b7669336236f8760