### PR TITLE
Add tests for database and lambda

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,35 @@
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from unittest.mock import MagicMock, patch
+
+import database
+from database import DatabaseManager
+
+
+def test_add_record_puts_item_and_returns_id():
+    table_mock = MagicMock()
+    with patch.object(database, "boto3") as mock_boto3, \
+         patch.object(database.uuid, "uuid4", return_value="test-id"):
+        mock_boto3.resource.return_value.Table.return_value = table_mock
+        db = DatabaseManager(table_name="tbl")
+        record = {"PatientName": "Alice"}
+        record_id = db.add_record(record.copy())
+
+    table_mock.put_item.assert_called_once()
+    item = table_mock.put_item.call_args.kwargs["Item"]
+    assert item["PatientName"] == "Alice"
+    assert item["RecordID"] == "test-id"
+    assert record_id == "test-id"
+
+
+def test_fetch_all_records_scans_table():
+    table_mock = MagicMock()
+    table_mock.scan.return_value = {"Items": [{"foo": "bar"}]}
+    with patch.object(database, "boto3") as mock_boto3:
+        mock_boto3.resource.return_value.Table.return_value = table_mock
+        db = DatabaseManager(table_name="tbl")
+        records = db.fetch_all_records()
+
+    table_mock.scan.assert_called_once()
+    assert records == [{"foo": "bar"}]

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,0 +1,53 @@
+import os, sys, json, importlib
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from unittest.mock import MagicMock, patch
+
+
+def load_lambda_with_stubs(db_stub, report_stub):
+    """Reload lambda_function with boto3 mocked and global stubs injected."""
+    with patch("database.boto3.resource") as mock_resource:
+        mock_resource.return_value.Table.return_value = MagicMock()
+        module = importlib.import_module("lambda_function")
+        importlib.reload(module)
+        module.db_manager = db_stub
+        module.report_generator = report_stub
+        return module
+
+
+class StubDB:
+    def __init__(self, record_id="123"):
+        self.record_id = record_id
+        self.add_record = MagicMock(return_value=record_id)
+
+
+class StubReport:
+    def __init__(self, data):
+        self._data = data
+
+    def outstanding_billables(self):
+        return self._data
+
+
+def test_lambda_handler_routes_to_report():
+    stub_report = StubReport({"ok": True})
+    module = load_lambda_with_stubs(StubDB(), stub_report)
+    event = {"httpMethod": "GET", "path": "/reports/outstanding_billables"}
+    resp = module.lambda_handler(event, None)
+    assert json.loads(resp["body"]) == {"ok": True}
+    assert resp["statusCode"] == 200
+
+
+def test_lambda_add_record_uses_db_stub():
+    db = StubDB(record_id="abc")
+    module = load_lambda_with_stubs(db, StubReport({}))
+    event = {
+        "httpMethod": "POST",
+        "path": "/add_record",
+        "body": json.dumps({"foo": "bar"}),
+    }
+    resp = module.lambda_handler(event, None)
+    db.add_record.assert_called_once_with({"foo": "bar"})
+    body = json.loads(resp["body"])
+    assert body == {"message": "Record added successfully!", "RecordID": "abc"}
+    assert resp["statusCode"] == 200


### PR DESCRIPTION
## Summary
- add DatabaseManager tests for add_record and fetch_all_records
- add lambda_handler tests for routing and record insertion

## Testing
- `pip install -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1f1e8d8483308f5f0c926391fac4